### PR TITLE
Add firefox support

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,5 +12,6 @@
     "js": ["jquery-3.2.1.min.js", "ipa.js"],
     "css": ["ipa.css"]
   }],
+  "permissions": ["https://www.ipaaudio.click/audio"],
   "web_accessible_resources": ["play-button.svg"]
 }


### PR DESCRIPTION
On firefox, for `fetch` to work, the fetched host needs to be added to permissions according to Mozilla's [WexExtension permissions guide](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).

This patch just adds the required permission to `manifest.json`.
Checked that it works on both Firefox 77 and Chrome 84.